### PR TITLE
Fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SteamDB.info
 
 Welcome to the GitHub page for [steamdb.info](https://steamdb.info/)! This repo only serves as a public issue tracker.
 
-For the actual code, see other repositories on [our GitHub organization page](https://github.com/SteamDatabase) or [our open-source landing page](https://opensource.steamdb.info/).
+For the actual code, see other repositories on [our GitHub organization page](https://github.com/SteamDatabase).
 
 ### Intro
 This tool was made to give better insight into the applications and packages that [Steam](https://store.steampowered.com/) has in its database.


### PR DESCRIPTION
Removes the link to https://opensource.steamdb.info/, which seems to be dead.